### PR TITLE
Update closure timer message

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,12 +122,16 @@
           timerEl.textContent = 'Portón cerrado';
           const msgEl = document.getElementById('msg');
           msgEl.textContent = 'Portón cerrado';
-          msgEl.className = 'ok';
+          msgEl.className = 'err';
           progress.style.width = '0%';
           setTimeout(() => {
             timerEl.style.display = 'none';
             progressContainer.style.display = 'none';
           }, 3000);
+          setTimeout(() => {
+            msgEl.textContent = '';
+            msgEl.className = '';
+          }, 10000);
         } else {
           timerEl.textContent = `Cierre en ${formatoTiempo(restantes)}`;
         }


### PR DESCRIPTION
## Summary
- show the "Portón cerrado" message as an error
- clear the message after 10 seconds

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_6848b03e851883238cc855f61a6b4ff4