### PR TITLE
Add simple gate usage logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+log.txt

--- a/index.html
+++ b/index.html
@@ -159,6 +159,12 @@
           method: 'POST'
         });
         if (res.ok) {
+          // registrar uso de forma local
+          await fetch('/log', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ pin: input })
+          });
           msg.textContent = '¡Listo! El portón se está abriendo.';
           msg.className = 'ok';
           iniciarTimer();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "gate",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,87 @@
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const WEBHOOK_URL = 'https://dyaxguerproyd2kte4awwggu9ylh6rsd.ui.nabu.casa/api/webhook/porton_martes';
+
+function serveIndex(res) {
+  fs.readFile(path.join(__dirname, 'index.html'), (err, data) => {
+    if (err) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Server error');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(data);
+  });
+}
+
+function appendLog(pin) {
+  const entry = `${new Date().toISOString()} - ${pin}\n`;
+  const file = path.join(__dirname, 'log.txt');
+  fs.appendFile(file, entry, err => {
+    if (err) console.error('Error writing log:', err);
+  });
+}
+
+function forwardWebhook(callback) {
+  const url = new URL(WEBHOOK_URL);
+  const options = {
+    method: 'POST',
+    hostname: url.hostname,
+    path: url.pathname + url.search,
+    protocol: url.protocol,
+    port: url.port || (url.protocol === 'https:' ? 443 : 80),
+    headers: { 'Content-Length': 0 }
+  };
+
+  const req = (url.protocol === 'https:' ? https : http).request(options, res => {
+    res.on('data', () => {});
+    res.on('end', () => callback());
+  });
+  req.on('error', err => {
+    console.error('Webhook error:', err);
+    callback();
+  });
+  req.end();
+}
+
+function handleLog(req, res) {
+  let body = '';
+  req.on('data', chunk => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    try {
+      const data = JSON.parse(body);
+      const pin = data.pin || 'unknown';
+      appendLog(pin);
+      forwardWebhook(() => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    } catch (err) {
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('Invalid data');
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/') {
+    serveIndex(res);
+    return;
+  }
+  if (req.method === 'POST' && req.url === '/log') {
+    handleLog(req, res);
+    return;
+  }
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not Found');
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node.js server to log gate usage and forward webhook
- send local logging request from gate page
- set up start script and ignore log files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851996a65b08323be13323506da5149