### PR TITLE
Add Supabase logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "@supabase/supabase-js": "^2.0.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add @supabase/supabase-js dependency
- initialize Supabase in `server.js`
- log PIN opens to Supabase
- read log entries from Supabase instead of `log.txt`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851a6a6f2348323a85c680254ca73b6