### PR TITLE
Improve empty log display in admin

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -79,11 +79,17 @@
       const data = await res.json();
       const tbody = document.querySelector('#log-table tbody');
       tbody.innerHTML = '';
-      data.entries.forEach(e => {
+      if (data.entries.length === 0) {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.user || 'Desconocido'}</td><td>${e.pin}</td>`;
+        tr.innerHTML = '<td colspan="3" class="text-center">Sin registros</td>';
         tbody.appendChild(tr);
-      });
+      } else {
+        data.entries.forEach(e => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.user || 'Desconocido'}</td><td>${e.pin}</td>`;
+          tbody.appendChild(tr);
+        });
+      }
     }
 
     async function cargarCodigos() {


### PR DESCRIPTION
## Summary
- show a placeholder row on the admin log table when no entries are found

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851a9e667e48323b5831df2de4b98c6