### PR TITLE
Improve admin time inputs

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Administración</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
 </head>
 <body class="bg-light">
   <div class="container py-4">
@@ -43,12 +45,28 @@
         </div>
       </div>
       <div class="col-md-auto">
-        <label class="form-label" for="hora-inicio">Inicio</label>
-        <input type="time" class="form-control" id="hora-inicio" required>
+        <label class="mdc-text-field mdc-text-field--outlined" id="hora-inicio-field">
+          <input type="text" class="mdc-text-field__input" id="hora-inicio" required>
+          <span class="mdc-notched-outline">
+            <span class="mdc-notched-outline__leading"></span>
+            <span class="mdc-notched-outline__notch">
+              <span class="mdc-floating-label">Inicio</span>
+            </span>
+            <span class="mdc-notched-outline__trailing"></span>
+          </span>
+        </label>
       </div>
       <div class="col-md-auto">
-        <label class="form-label" for="hora-fin">Fin</label>
-        <input type="time" class="form-control" id="hora-fin" required>
+        <label class="mdc-text-field mdc-text-field--outlined" id="hora-fin-field">
+          <input type="text" class="mdc-text-field__input" id="hora-fin" required>
+          <span class="mdc-notched-outline">
+            <span class="mdc-notched-outline__leading"></span>
+            <span class="mdc-notched-outline__notch">
+              <span class="mdc-floating-label">Fin</span>
+            </span>
+            <span class="mdc-notched-outline__trailing"></span>
+          </span>
+        </label>
       </div>
       <div class="col-12">
         <button type="submit" class="btn btn-primary mt-2">Agregar</button>
@@ -69,7 +87,13 @@
     </table>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script>
+    const inicioField = new mdc.textField.MDCTextField(document.getElementById('hora-inicio-field'));
+    const finField = new mdc.textField.MDCTextField(document.getElementById('hora-fin-field'));
+    flatpickr('#hora-inicio', {enableTime: true, noCalendar: true, dateFormat: 'H:i'});
+    flatpickr('#hora-fin', {enableTime: true, noCalendar: true, dateFormat: 'H:i'});
     async function cargarLogs() {
       const res = await fetch('/logs');
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- use Material Design text fields and time picker modules
- load Material Components CSS/JS
- initialize MDCTextField with flatpickr time pickers

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851a9e89c80832383cac9159d39c1e9