### PR TITLE
Add admin logs page with navigation

### DIFF
--- a/admin-logs.html
+++ b/admin-logs.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Registros</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { background-color: #f5f5f5; }
+  </style>
+</head>
+<body class="bg-light">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Admin</a>
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="/admin-logs">Registros</a></li>
+        <li class="nav-item"><a class="nav-link" href="/admin">Códigos</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div class="container py-4">
+    <h1 class="mb-4">Registro de Uso del Portón</h1>
+    <table class="table table-striped" id="log-table">
+      <thead>
+        <tr>
+          <th>Fecha y Hora</th>
+          <th>Usuario</th>
+          <th>PIN</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    async function cargarLogs() {
+      const res = await fetch('/logs');
+      if (!res.ok) {
+        alert('No se pudo obtener el log');
+        return;
+      }
+      const data = await res.json();
+      const tbody = document.querySelector('#log-table tbody');
+      tbody.innerHTML = '';
+      data.entries.forEach(e => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.user || 'Desconocido'}</td><td>${e.pin}</td>`;
+        tbody.appendChild(tr);
+      });
+    }
+
+    cargarLogs();
+  </script>
+</body>
+</html>

--- a/admin.html
+++ b/admin.html
@@ -5,24 +5,25 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Administración</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body {
+      background-color: #f5f5f5;
+    }
+  </style>
 </head>
 <body class="bg-light">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Admin</a>
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="/admin-logs">Registros</a></li>
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="/admin">Códigos</a></li>
+      </ul>
+    </div>
+  </nav>
+
   <div class="container py-4">
-    <h1 class="mb-4">Registro de Uso del Portón</h1>
-    <table class="table table-striped" id="log-table">
-      <thead>
-        <tr>
-          <th>Fecha y Hora</th>
-          <th>Usuario</th>
-          <th>PIN</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-
-    <hr class="my-4">
-
-    <h2 class="mt-4">Agregar Código</h2>
+    <h1 class="mb-4">Administrar Códigos</h1>
     <form id="code-form" class="row gy-2 gx-3 align-items-end">
       <div class="col-auto">
         <input type="text" class="form-control" id="new-pin" placeholder="PIN" maxlength="4" required>
@@ -70,21 +71,6 @@
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script>
-    async function cargarLogs() {
-      const res = await fetch('/logs');
-      if (!res.ok) {
-        alert('No se pudo obtener el log');
-        return;
-      }
-      const data = await res.json();
-      const tbody = document.querySelector('#log-table tbody');
-      tbody.innerHTML = '';
-      data.entries.forEach(e => {
-        const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.user || 'Desconocido'}</td><td>${e.pin}</td>`;
-        tbody.appendChild(tr);
-      });
-    }
 
     async function cargarCodigos() {
       const res = await fetch('/codes');
@@ -120,7 +106,6 @@
       }
     });
 
-    cargarLogs();
     cargarCodigos();
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -79,6 +79,18 @@ function serveAdmin(res) {
   });
 }
 
+function serveAdminLogs(res) {
+  fs.readFile(path.join(__dirname, 'admin-logs.html'), (err, data) => {
+    if (err) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Server error');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(data);
+  });
+}
+
 async function readLogs() {
   const { data, error } = await supabase
     .from('logs')
@@ -160,6 +172,10 @@ const server = http.createServer((req, res) => {
   }
   if (req.method === 'GET' && req.url === '/admin') {
     serveAdmin(res);
+    return;
+  }
+  if (req.method === 'GET' && req.url === '/admin-logs') {
+    serveAdminLogs(res);
     return;
   }
   if (req.method === 'GET' && req.url === '/logs') {


### PR DESCRIPTION
## Summary
- add Material-like navigation to admin pages
- split logs table out to new `admin-logs.html`
- serve `admin-logs` route in the server

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_6851a9e9cfbc8323add5c8a5bf16f69f