### PR TITLE
Allow alphanumeric PINs and split admin page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -327,39 +327,19 @@
       </div>
     </div>
 
-    <!-- Logs Card -->
-    <div class="card">
-      <div class="card-header">
-        <h5 class="card-title">
-          <i class="fas fa-history text-primary"></i>
-          Registro de Actividad
-          <span class="badge bg-primary ms-2" id="log-count">0</span>
-        </h5>
-      </div>
-      <div class="card-body">
-        <div class="table-responsive">
-          <table class="table" id="log-table">
-            <thead>
-              <tr>
-                <th><i class="fas fa-clock me-2"></i>Fecha y Hora</th>
-                <th><i class="fas fa-user me-2"></i>Usuario</th>
-                <th><i class="fas fa-key me-2"></i>PIN</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td colspan="3" class="text-center">
-                  <div class="loading-spinner me-2"></div>
-                  Cargando registros...
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
+    <!-- Navigation Tabs -->
+    <ul class="nav nav-tabs mt-4" id="adminTabs" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="codes-tab" data-bs-toggle="tab" data-bs-target="#codes" type="button" role="tab">Códigos</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="logs-tab" data-bs-toggle="tab" data-bs-target="#logs" type="button" role="tab">Registro de Actividad</button>
+      </li>
+    </ul>
+    <div class="tab-content pt-3">
+      <div class="tab-pane fade show active" id="codes" role="tabpanel" aria-labelledby="codes-tab">
 
-    <!-- Add Code Card -->
+        <!-- Add Code Card -->
     <div class="card">
       <div class="card-header">
         <h5 class="card-title">
@@ -372,9 +352,9 @@
           <div class="row mb-3">
             <div class="col-md-6">
               <label for="new-pin" class="form-label">
-                <i class="fas fa-key me-2"></i>PIN (4 dígitos)
+                <i class="fas fa-key me-2"></i>PIN (4-10 caracteres)
               </label>
-              <input type="text" class="form-control" id="new-pin" placeholder="Ej: 1234" maxlength="4" pattern="[0-9]{4}" required>
+              <input type="text" class="form-control" id="new-pin" placeholder="Ej: A123" minlength="4" maxlength="10" pattern="[A-Za-z0-9]{4,10}" required>
             </div>
             <div class="col-md-6">
               <label for="new-user" class="form-label">
@@ -471,6 +451,40 @@
               </tr>
             </tbody>
           </table>
+        </div>
+      </div>
+    </div>
+      <div class="tab-pane fade" id="logs" role="tabpanel" aria-labelledby="logs-tab">
+        <!-- Logs Card -->
+        <div class="card">
+          <div class="card-header">
+            <h5 class="card-title">
+              <i class="fas fa-history text-primary"></i>
+              Registro de Actividad
+              <span class="badge bg-primary ms-2" id="log-count">0</span>
+            </h5>
+          </div>
+          <div class="card-body">
+            <div class="table-responsive">
+              <table class="table" id="log-table">
+                <thead>
+                  <tr>
+                    <th><i class="fas fa-clock me-2"></i>Fecha y Hora</th>
+                    <th><i class="fas fa-user me-2"></i>Usuario</th>
+                    <th><i class="fas fa-key me-2"></i>PIN</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td colspan="3" class="text-center">
+                      <div class="loading-spinner me-2"></div>
+                      Cargando registros...
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -626,6 +640,9 @@
       
       try {
         const pin = document.getElementById('new-pin').value.trim();
+        if (pin.length < 4 || pin.length > 10) {
+          throw new Error('El PIN debe tener entre 4 y 10 caracteres');
+        }
         const user = document.getElementById('new-user').value.trim();
         const start = document.getElementById('hora-inicio').value;
         const end = document.getElementById('hora-fin').value;
@@ -659,7 +676,8 @@
           Código agregado exitosamente
           <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         `;
-        document.querySelector('.card-body').insertBefore(alert, document.getElementById('code-form'));
+        const formBody = document.getElementById('code-form').parentElement;
+        formBody.insertBefore(alert, document.getElementById('code-form'));
         
         setTimeout(() => alert.remove(), 5000);
         cargarCodigos();
@@ -673,7 +691,8 @@
           Error: ${error.message}
           <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         `;
-        document.querySelector('.card-body').insertBefore(alert, document.getElementById('code-form'));
+        const formBodyErr = document.getElementById('code-form').parentElement;
+        formBodyErr.insertBefore(alert, document.getElementById('code-form'));
         
         setTimeout(() => alert.remove(), 5000);
       } finally {
@@ -684,7 +703,7 @@
 
     // Input validation for PIN
     document.getElementById('new-pin').addEventListener('input', function(e) {
-      e.target.value = e.target.value.replace(/[^0-9]/g, '');
+      e.target.value = e.target.value.replace(/[^A-Za-z0-9]/g, '');
     });
 
     // Auto-refresh logs every 30 seconds

--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
   <div class="main-container">
     <div class="container">
       <h2>Control de Acceso</h2>
-      <input type="password" maxlength="4" id="codigo" autocomplete="one-time-code" placeholder="••••">
+      <input type="text" minlength="4" maxlength="10" id="codigo" autocomplete="one-time-code" placeholder="Ingrese PIN">
       <button class="open-button" onclick="abrirPorton()" id="open-btn">
         <i class="fas fa-key"></i>
         <span>Abrir Portón</span>
@@ -304,8 +304,8 @@
       msg.textContent = '';
       msg.className = '';
       
-      if (input.length !== 4) {
-        msg.innerHTML = '<i class="fas fa-exclamation-triangle"></i> Ingresá los 4 dígitos completos.';
+      if (input.length < 4 || input.length > 10) {
+        msg.innerHTML = '<i class="fas fa-exclamation-triangle"></i> Ingresá entre 4 y 10 caracteres.';
         msg.className = 'err';
         return;
       }
@@ -364,11 +364,11 @@
 
     // Add some visual feedback for the input
     document.getElementById('codigo').addEventListener('input', function(e) {
-      // Only allow numbers
-      e.target.value = e.target.value.replace(/[^0-9]/g, '');
-      
-      // Add visual feedback when 4 digits are entered
-      if (e.target.value.length === 4) {
+      // Only allow letters and numbers
+      e.target.value = e.target.value.replace(/[^A-Za-z0-9]/g, '');
+
+      // Add visual feedback when minimum length reached
+      if (e.target.value.length >= 4) {
         e.target.style.borderColor = '#00c6ff';
         e.target.style.boxShadow = '0 0 0 2px #00c6ff55';
       } else {

--- a/netlify/functions/codes.js
+++ b/netlify/functions/codes.js
@@ -46,8 +46,16 @@ exports.handler = async (event, context) => {
 
     if (event.httpMethod === 'POST') {
       const data = JSON.parse(event.body);
+      const pin = String(data.pin || '').trim();
+      if (!/^[A-Za-z0-9]{4,10}$/.test(pin)) {
+        return {
+          statusCode: 400,
+          headers,
+          body: JSON.stringify({ error: 'PIN inválido' })
+        };
+      }
       await saveCode({
-        pin: String(data.pin),
+        pin,
         user: data.user || '',
         days: Array.isArray(data.days) ? data.days : [],
         start: data.start || '00:00',

--- a/server.js
+++ b/server.js
@@ -285,8 +285,14 @@ const server = http.createServer((req, res) => {
     req.on('end', async () => {
       try {
         const data = JSON.parse(body);
+
+        const pin = String(data.pin || '').trim();
+        if (!/^[A-Za-z0-9]{4,10}$/.test(pin)) {
+          throw new Error('PIN must be 4-10 letters or numbers');
+        }
+
         await saveCode({
-          pin: String(data.pin),
+          pin,
           username: data.user || '',
           days: Array.isArray(data.days) ? data.days : [],
           start_time: data.start || '00:00',


### PR DESCRIPTION
## Summary
- validate PINs to allow 4-10 alphanumeric chars
- handle invalid PINs in Netlify function
- split admin page into tabs and update PIN input rules
- support alphanumeric PIN entry on main page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851d93cb0908323ae79763b3ee53ba9