### PR TITLE
Add timezone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,19 @@ Run `npm install` to install the project dependencies.
 
 ## Environment Variables
 
-Both the local server and the Netlify Functions need access to Supabase. Define
-the following variables:
+Both the local server and the Netlify Functions need access to Supabase and
+some configuration details. Define the following variables:
 
 - `SUPABASE_URL` – URL of your Supabase instance.
 - `SUPABASE_SERVICE_KEY` – Service role key with access to your database.
+- `TIMEZONE` – IANA time zone used when validating code schedules (defaults to
+  `UTC`).
 
 When deploying to Netlify, set these variables in the **Site settings →
-Environment variables** section of the Netlify dashboard. For local development,
-create a `.env` file in the project root with the variables in the form:
+Environment variables** section of the Netlify dashboard. Remember to define
+`TIMEZONE` so that schedule restrictions are evaluated correctly. For local
+development, create a `.env` file in the project root with the variables in the
+form:
 
 ```bash
 SUPABASE_URL=your-supabase-url

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -3,6 +3,7 @@ const request = require('supertest');
 // Set minimal environment variables so the server does not exit on load
 process.env.SUPABASE_URL = 'http://localhost';
 process.env.SUPABASE_SERVICE_KEY = 'test-key';
+process.env.TIMEZONE = 'UTC';
 
 jest.mock('@supabase/supabase-js', () => {
   return {

--- a/netlify/functions/open.js
+++ b/netlify/functions/open.js
@@ -13,8 +13,13 @@ function minutes(t) {
   return h * 60 + m;
 }
 
+function getNow() {
+  const tz = process.env.TIMEZONE || 'UTC';
+  return new Date(new Date().toLocaleString('en-US', { timeZone: tz }));
+}
+
 function codeAllowed(code) {
-  const now = new Date();
+  const now = getNow();
   const day = now.getDay();
   if (!code.days.includes(day)) return false;
   const cur = now.getHours() * 60 + now.getMinutes();

--- a/server.js
+++ b/server.js
@@ -96,8 +96,13 @@ function minutes(t) {
   return h*60 + m;
 }
 
+function getNow() {
+  const tz = process.env.TIMEZONE || 'UTC';
+  return new Date(new Date().toLocaleString('en-US', { timeZone: tz }));
+}
+
 function codeAllowed(code) {
-  const now = new Date();
+  const now = getNow();
   const day = now.getDay();
   if (!code.days.includes(day)) return false;
   const cur = now.getHours() * 60 + now.getMinutes();


### PR DESCRIPTION
## Summary
- document TIMEZONE environment variable
- add `getNow()` helper in server and Netlify function
- use `getNow()` inside `codeAllowed`
- update tests to define TIMEZONE

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851fd599fb48323b29dde7d94686363