### PR TITLE
Switch admin to Material Components

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -4,48 +4,104 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Administración</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Roboto', sans-serif;
+      background: #f5f5f5;
+      padding: 1rem;
+    }
+
+    .container {
+      max-width: 960px;
+      margin: auto;
+      background: #fff;
+      padding: 2rem;
+      border-radius: 4px;
+    }
+
+    h1, h2 {
+      font-weight: 500;
+    }
+
+    #dias {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      margin-top: 0.5rem;
+    }
+
+    #dias label {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-weight: 400;
+    }
+
+    .mdc-button--small {
+      --mdc-typography-button-font-size: 0.75rem;
+      padding-inline: 8px;
+    }
+
+    .center { text-align: center; }
+  </style>
 </head>
-<body class="bg-light">
-  <div class="container py-4">
-    <h1 class="mb-4">Registro de Uso del Portón</h1>
-    <table class="table table-striped" id="log-table">
-      <thead>
-        <tr>
-          <th>Fecha y Hora</th>
-          <th>Usuario</th>
-          <th>PIN</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+<body class="mdc-typography">
+  <div class="container">
+    <h1 style="margin-bottom:1rem;">Registro de Uso del Portón</h1>
+    <div class="mdc-data-table">
+      <table class="mdc-data-table__table" id="log-table" aria-label="Logs">
+        <thead>
+          <tr>
+            <th>Fecha y Hora</th>
+            <th>Usuario</th>
+            <th>PIN</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
 
-    <hr class="my-4">
+    <hr style="margin:2rem 0;">
 
-    <h2 class="mt-4" id="form-title">Agregar Código</h2>
-    <form id="code-form" class="row gy-2 gx-3 align-items-end">
+    <h2 id="form-title" style="margin-top:1rem;">Agregar Código</h2>
+    <form id="code-form">
       <input type="hidden" id="edit-pin" value="">
-      <div class="col-auto">
-        <input type="text" class="form-control" id="new-pin" placeholder="PIN" maxlength="4" required>
+      <div class="mdc-text-field mdc-text-field--outlined" id="new-pin-field">
+        <input type="text" class="mdc-text-field__input" id="new-pin" maxlength="4" required>
+        <span class="mdc-notched-outline">
+          <span class="mdc-notched-outline__leading"></span>
+          <span class="mdc-notched-outline__notch">
+            <span class="mdc-floating-label">PIN</span>
+          </span>
+          <span class="mdc-notched-outline__trailing"></span>
+        </span>
       </div>
-      <div class="col-auto">
-        <input type="text" class="form-control" id="new-user" placeholder="Usuario" required>
+      <div class="mdc-text-field mdc-text-field--outlined" id="new-user-field" style="margin-left:1rem;">
+        <input type="text" class="mdc-text-field__input" id="new-user" required>
+        <span class="mdc-notched-outline">
+          <span class="mdc-notched-outline__leading"></span>
+          <span class="mdc-notched-outline__notch">
+            <span class="mdc-floating-label">Usuario</span>
+          </span>
+          <span class="mdc-notched-outline__trailing"></span>
+        </span>
       </div>
-      <div class="col-12">
-        <label class="form-label d-block">Días habilitados</label>
-        <div id="dias" class="d-flex flex-wrap gap-3">
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="0" id="d0"><label class="form-check-label" for="d0">Dom</label></div>
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="1" id="d1"><label class="form-check-label" for="d1">Lun</label></div>
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="2" id="d2"><label class="form-check-label" for="d2">Mar</label></div>
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="3" id="d3"><label class="form-check-label" for="d3">Mié</label></div>
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="4" id="d4"><label class="form-check-label" for="d4">Jue</label></div>
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="5" id="d5"><label class="form-check-label" for="d5">Vie</label></div>
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="6" id="d6"><label class="form-check-label" for="d6">Sáb</label></div>
+      <div style="margin-top:1rem;">
+        <label>Días habilitados</label>
+        <div id="dias">
+          <label><input type="checkbox" value="0" id="d0"><span>Dom</span></label>
+          <label><input type="checkbox" value="1" id="d1"><span>Lun</span></label>
+          <label><input type="checkbox" value="2" id="d2"><span>Mar</span></label>
+          <label><input type="checkbox" value="3" id="d3"><span>Mié</span></label>
+          <label><input type="checkbox" value="4" id="d4"><span>Jue</span></label>
+          <label><input type="checkbox" value="5" id="d5"><span>Vie</span></label>
+          <label><input type="checkbox" value="6" id="d6"><span>Sáb</span></label>
         </div>
       </div>
-      <div class="col-md-auto">
+      <div style="display:flex; gap:1rem; margin-top:1rem;">
         <label class="mdc-text-field mdc-text-field--outlined" id="hora-inicio-field">
           <input type="text" class="mdc-text-field__input" id="hora-inicio" required>
           <span class="mdc-notched-outline">
@@ -56,8 +112,6 @@
             <span class="mdc-notched-outline__trailing"></span>
           </span>
         </label>
-      </div>
-      <div class="col-md-auto">
         <label class="mdc-text-field mdc-text-field--outlined" id="hora-fin-field">
           <input type="text" class="mdc-text-field__input" id="hora-fin" required>
           <span class="mdc-notched-outline">
@@ -69,30 +123,37 @@
           </span>
         </label>
       </div>
-      <div class="col-12">
-        <button type="submit" class="btn btn-primary mt-2" id="submit-btn">Agregar</button>
-        <button type="button" class="btn btn-secondary mt-2 ms-2" id="cancel-btn" onclick="cancelEdit()" style="display: none;">Cancelar</button>
+      <div style="margin-top:1rem;">
+        <button type="submit" class="mdc-button mdc-button--raised" id="submit-btn">
+          <span class="mdc-button__label">Agregar</span>
+        </button>
+        <button type="button" class="mdc-button" id="cancel-btn" onclick="cancelEdit()" style="display: none; margin-left:0.5rem;">
+          <span class="mdc-button__label">Cancelar</span>
+        </button>
       </div>
     </form>
 
-    <h2 class="mt-5">Códigos Actuales</h2>
-    <table class="table table-striped" id="code-table">
-      <thead>
-        <tr>
-          <th>PIN</th>
-          <th>Usuario</th>
-          <th>Días</th>
-          <th>Horario</th>
-          <th>Acciones</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <h2 style="margin-top:2rem;">Códigos Actuales</h2>
+    <div class="mdc-data-table">
+      <table class="mdc-data-table__table" id="code-table" aria-label="Códigos">
+        <thead>
+          <tr>
+            <th>PIN</th>
+            <th>Usuario</th>
+            <th>Días</th>
+            <th>Horario</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script>
+    const pinField = new mdc.textField.MDCTextField(document.getElementById('new-pin-field'));
+    const userField = new mdc.textField.MDCTextField(document.getElementById('new-user-field'));
     const inicioField = new mdc.textField.MDCTextField(document.getElementById('hora-inicio-field'));
     const finField = new mdc.textField.MDCTextField(document.getElementById('hora-fin-field'));
     flatpickr('#hora-inicio', {enableTime: true, noCalendar: true, dateFormat: 'H:i'});
@@ -118,7 +179,7 @@
         tbody.innerHTML = '';
         if (data.entries.length === 0) {
           const tr = document.createElement('tr');
-          tr.innerHTML = '<td colspan="3" class="text-center">Sin registros</td>';
+          tr.innerHTML = '<td colspan="3" class="center">Sin registros</td>';
           tbody.appendChild(tr);
         } else {
           data.entries.forEach(e => {
@@ -152,8 +213,8 @@
             <td>${dias}</td>
             <td>${c.start_time} - ${c.end_time}</td>
             <td>
-              <button class="btn btn-sm btn-outline-primary me-1" onclick="editCode('${c.pin}')">Editar</button>
-              <button class="btn btn-sm btn-outline-danger" onclick="deleteCode('${c.pin}')">Eliminar</button>
+              <button class="mdc-button mdc-button--outlined mdc-button--small" onclick="editCode('${c.pin}')"><span class="mdc-button__label">Editar</span></button>
+              <button class="mdc-button mdc-button--outlined mdc-button--small" onclick="deleteCode('${c.pin}')"><span class="mdc-button__label">Eliminar</span></button>
             </td>
           `;
           tbody.appendChild(tr);


### PR DESCRIPTION
## Summary
- drop Bootstrap assets
- integrate Material Components Web for styling
- rewrite admin form and table using Material markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851fe1c5dd88323b87741c439849819