### PR TITLE
Add dedicated logs view

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -10,19 +10,8 @@
 </head>
 <body class="bg-light">
   <div class="container py-4">
-    <h1 class="mb-4">Registro de Uso del Portón</h1>
-    <table class="table table-striped" id="log-table">
-      <thead>
-        <tr>
-          <th>Fecha y Hora</th>
-          <th>Usuario</th>
-          <th>PIN</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-
-    <hr class="my-4">
+    <h1 class="mb-4">Administración de Códigos</h1>
+    <a href="/logs-view" class="btn btn-outline-secondary mb-4">Ver Logs</a>
 
     <h2 class="mt-4" id="form-title">Agregar Código</h2>
     <form id="code-form" class="row gy-2 gx-3 align-items-end">
@@ -106,32 +95,6 @@
       return days.map(day => dayNames[day]).join(', ');
     }
 
-    async function cargarLogs() {
-      try {
-        const res = await fetch('/logs');
-        if (!res.ok) {
-          alert('No se pudo obtener el log');
-          return;
-        }
-        const data = await res.json();
-        const tbody = document.querySelector('#log-table tbody');
-        tbody.innerHTML = '';
-        if (data.entries.length === 0) {
-          const tr = document.createElement('tr');
-          tr.innerHTML = '<td colspan="3" class="text-center">Sin registros</td>';
-          tbody.appendChild(tr);
-        } else {
-          data.entries.forEach(e => {
-            const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.username || 'Desconocido'}</td><td>${e.pin}</td>`;
-            tbody.appendChild(tr);
-          });
-        }
-      } catch (error) {
-        console.error('Error loading logs:', error);
-        alert('Error al cargar los logs');
-      }
-    }
 
     async function cargarCodigos() {
       try {
@@ -289,7 +252,6 @@
     });
 
     // Initialize
-    cargarLogs();
     cargarCodigos();
   </script>
 </body>

--- a/logs.html
+++ b/logs.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Registro de Logs</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container py-4">
+    <h1 class="mb-4">Registro de Uso del Portón</h1>
+    <table class="table table-striped" id="log-table">
+      <thead>
+        <tr>
+          <th>Fecha y Hora</th>
+          <th>Usuario</th>
+          <th>PIN</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    async function cargarLogs() {
+      try {
+        const res = await fetch('/logs');
+        if (!res.ok) {
+          alert('No se pudo obtener el log');
+          return;
+        }
+        const data = await res.json();
+        const tbody = document.querySelector('#log-table tbody');
+        tbody.innerHTML = '';
+        if (data.entries.length === 0) {
+          const tr = document.createElement('tr');
+          tr.innerHTML = '<td colspan="3" class="text-center">Sin registros</td>';
+          tbody.appendChild(tr);
+        } else {
+          data.entries.forEach(e => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.username || 'Desconocido'}</td><td>${e.pin}</td>`;
+            tbody.appendChild(tr);
+          });
+        }
+      } catch (error) {
+        console.error('Error loading logs:', error);
+        alert('Error al cargar los logs');
+      }
+    }
+
+    cargarLogs();
+  </script>
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,6 +28,11 @@
   to = "/.netlify/functions/open"
   status = 200
 
+[[redirects]]
+  from = "/logs-view"
+  to = "/logs.html"
+  status = 200
+
 # Environment variables for build (you'll need to set these in Netlify dashboard)
 [build.environment]
   NODE_VERSION = "18"

--- a/server.js
+++ b/server.js
@@ -150,6 +150,18 @@ function serveAdmin(res) {
   });
 }
 
+function serveLogsPage(res) {
+  fs.readFile(path.join(__dirname, 'logs.html'), (err, data) => {
+    if (err) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Server error');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(data);
+  });
+}
+
 async function readLogs() {
   try {
     const { data, error } = await supabase
@@ -253,6 +265,10 @@ const server = http.createServer((req, res) => {
   }
   if (req.method === 'GET' && req.url === '/admin') {
     serveAdmin(res);
+    return;
+  }
+  if (req.method === 'GET' && req.url === '/logs-view') {
+    serveLogsPage(res);
     return;
   }
   if (req.method === 'GET' && req.url === '/logs') {


### PR DESCRIPTION
## Summary
- create `logs.html` page to display logs
- strip log table from `admin.html` and link to the new page
- serve new page from `/logs-view` in `server.js`
- map `/logs-view` to `logs.html` in Netlify configuration

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851fe1f240483239894acbb9a148499