### PR TITLE
Expose WEBHOOK_URL via env var

### DIFF
--- a/.env
+++ b/.env
@@ -5,5 +5,8 @@ SUPABASE_SERVICE_KEY=your-service-role-key
 # Timezone for schedule validation (important!)
 TIMEZONE=America/Costa_Rica
 
+# URL to call when a valid code opens the gate
+WEBHOOK_URL=https://dyaxguerproyd2kte4awwggu9ylh6rsd.ui.nabu.casa/api/webhook/porton_martes
+
 # Server Port (optional)
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ some configuration details. Define the following variables:
 - `SUPABASE_SERVICE_KEY` – Service role key with access to your database.
 - `TIMEZONE` – IANA time zone used when validating code schedules (defaults to
   `UTC`).
+- `WEBHOOK_URL` – Endpoint triggered when a valid code opens the gate.
 
 When deploying to Netlify, set these variables in the **Site settings →
 Environment variables** section of the Netlify dashboard. Remember to define
@@ -31,6 +32,8 @@ form:
 ```bash
 SUPABASE_URL=your-supabase-url
 SUPABASE_SERVICE_KEY=your-service-key
+TIMEZONE=America/Costa_Rica
+WEBHOOK_URL=https://my-home-assistant.example/api/webhook/porton
 ```
 
 ## Running Locally

--- a/netlify/functions/open.js
+++ b/netlify/functions/open.js
@@ -6,7 +6,8 @@ const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
-const WEBHOOK_URL = 'https://dyaxguerproyd2kte4awwggu9ylh6rsd.ui.nabu.casa/api/webhook/porton_martes';
+const WEBHOOK_URL = process.env.WEBHOOK_URL ||
+  'https://dyaxguerproyd2kte4awwggu9ylh6rsd.ui.nabu.casa/api/webhook/porton_martes';
 
 function minutes(t) {
   const [h, m] = t.split(':').map(Number);

--- a/server.js
+++ b/server.js
@@ -8,6 +8,8 @@ const { createClient } = require('@supabase/supabase-js');
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
 const TIMEZONE = process.env.TIMEZONE || 'America/Costa_Rica'; // Default to Costa Rica timezone
+const WEBHOOK_URL = process.env.WEBHOOK_URL ||
+  'https://dyaxguerproyd2kte4awwggu9ylh6rsd.ui.nabu.casa/api/webhook/porton_martes';
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
 async function loadCodes() {
@@ -89,8 +91,6 @@ async function pinAllowed(pin) {
   
   return allowed ? data : null;
 }
-
-const WEBHOOK_URL = 'https://dyaxguerproyd2kte4awwggu9ylh6rsd.ui.nabu.casa/api/webhook/porton_martes';
 
 function serveIndex(res) {
   fs.readFile(path.join(__dirname, 'index.html'), (err, data) => {


### PR DESCRIPTION
## Summary
- use `WEBHOOK_URL` environment variable in `server.js`
- use `WEBHOOK_URL` environment variable in the open function
- document `WEBHOOK_URL` in `.env`
- explain `WEBHOOK_URL` in the README example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852be3acdac8323a3e4c30438c45ba2