### PR TITLE
Improve webhook error handling

### DIFF
--- a/netlify/functions/open.js
+++ b/netlify/functions/open.js
@@ -55,7 +55,7 @@ async function appendLog(pin, user) {
 }
 
 function forwardWebhook() {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const url = new URL(WEBHOOK_URL);
     const options = {
       method: 'POST',
@@ -67,13 +67,22 @@ function forwardWebhook() {
     };
 
     const req = (url.protocol === 'https:' ? https : http).request(options, res => {
+      console.log(`Webhook response status: ${res.statusCode}`);
       res.on('data', () => {});
-      res.on('end', () => resolve());
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          resolve();
+        } else {
+          reject(new Error(`Webhook failed with status ${res.statusCode}`));
+        }
+      });
     });
+
     req.on('error', err => {
       console.error('Webhook error:', err);
-      resolve();
+      reject(err);
     });
+
     req.end();
   });
 }
@@ -125,8 +134,18 @@ exports.handler = async (event, context) => {
 
     console.log(`Netlify function: PIN ${pin} accepted for user ${code.user}`);
     await appendLog(pin, code.user);
-    await forwardWebhook();
-    
+
+    try {
+      await forwardWebhook();
+    } catch (err) {
+      console.error('Webhook call failed:', err);
+      return {
+        statusCode: 500,
+        headers,
+        body: JSON.stringify({ ok: false, error: 'Error al abrir el port\u00f3n. Intenta de nuevo.' })
+      };
+    }
+
     return {
       statusCode: 200,
       headers,


### PR DESCRIPTION
## Summary
- check webhook status code in `forwardWebhook`
- return an error response if the webhook fails
- log webhook HTTP status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852be3bd8a08323954e0ef1f0c37d69