### PR TITLE
Consistent `user` field

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -111,7 +111,7 @@
           const tr = document.createElement('tr');
           tr.innerHTML = `
             <td>${c.pin}</td>
-            <td>${c.username}</td>
+            <td>${c.user}</td>
             <td>${dias}</td>
             <td>${c.start_time} - ${c.end_time}</td>
             <td>
@@ -139,7 +139,7 @@
         document.getElementById('edit-pin').value = pin;
         document.getElementById('new-pin').value = pin;
         document.getElementById('new-pin').disabled = true;
-        document.getElementById('new-user').value = code.username;
+        document.getElementById('new-user').value = code.user || code.username || '';
         document.getElementById('hora-inicio').value = code.start_time;
         document.getElementById('hora-fin').value = code.end_time;
 
@@ -205,17 +205,17 @@
       
       try {
         const pin = document.getElementById('new-pin').value.trim();
-        const username = document.getElementById('new-user').value.trim();
+        const user = document.getElementById('new-user').value.trim();
         const start_time = document.getElementById('hora-inicio').value;
         const end_time = document.getElementById('hora-fin').value;
         const days = Array.from(document.querySelectorAll('#dias input:checked')).map(cb => parseInt(cb.value));
 
-        if (!pin || !username || !start_time || !end_time) {
+        if (!pin || !user || !start_time || !end_time) {
           alert('Por favor completa todos los campos');
           return;
         }
 
-        const data = { pin, username, start_time, end_time, days };
+        const data = { pin, user, start_time, end_time, days };
         console.log('Sending data:', data);
 
         let res;

--- a/codes.json
+++ b/codes.json
@@ -1,7 +1,7 @@
 [
   {
     "pin": "7777",
-    "username": "Carlos Mendoza",
+    "user": "Carlos Mendoza",
     "days": [0,1,2,3,4,5,6],
     "start_time": "00:00",
     "end_time": "23:59"

--- a/logs.html
+++ b/logs.html
@@ -41,7 +41,8 @@
         } else {
           data.entries.forEach(e => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.username || 'Desconocido'}</td><td>${e.pin}</td>`;
+            const user = e.user || e.username || 'Desconocido';
+            tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${user}</td><td>${e.pin}</td>`;
             tbody.appendChild(tr);
           });
         }

--- a/netlify/functions/codes.js
+++ b/netlify/functions/codes.js
@@ -79,7 +79,7 @@ exports.handler = async (event, context) => {
       }
       await saveCode({
         pin,
-        username: data.username || '',
+        user: data.user || '',
         days: Array.isArray(data.days) ? data.days : [],
         start_time: data.start_time || '00:00',
         end_time: data.end_time || '23:59'
@@ -96,7 +96,7 @@ exports.handler = async (event, context) => {
       const pin = decodeURIComponent(event.path.split('/').pop());
       const data = JSON.parse(event.body || '{}');
       await updateCode(pin, {
-        username: data.username || '',
+        user: data.user || '',
         days: Array.isArray(data.days) ? data.days : [],
         start_time: data.start_time || '00:00',
         end_time: data.end_time || '23:59'

--- a/netlify/functions/open.js
+++ b/netlify/functions/open.js
@@ -123,8 +123,9 @@ exports.handler = async (event, context) => {
       };
     }
 
-    console.log(`Netlify function: PIN ${pin} accepted for user ${code.user}`);
-    await appendLog(pin, code.user);
+    const user = code.user || code.username || 'Unknown';
+    console.log(`Netlify function: PIN ${pin} accepted for user ${user}`);
+    await appendLog(pin, user);
     await forwardWebhook();
     
     return {

--- a/server.js
+++ b/server.js
@@ -38,7 +38,8 @@ function codeAllowed(code) {
   const now = new Date(getCurrentTimeInTimezone());
   const day = now.getDay();
   
-  console.log(`Checking code for user ${code.user}:`);
+  const user = code.user || code.username || 'Unknown';
+  console.log(`Checking code for user ${user}:`);
   console.log(`  Current time (${TIMEZONE}): ${now.toLocaleString()}`);
   console.log(`  Current day: ${day} (0=Sunday, 6=Saturday)`);
   console.log(`  Allowed days: [${code.days.join(', ')}]`);
@@ -83,7 +84,7 @@ async function pinAllowed(pin) {
     return null;
   }
   
-  console.log(`✅ PIN found for user: ${data.user}`);
+  console.log(`✅ PIN found for user: ${data.user || data.username}`);
   const allowed = codeAllowed(data);
   console.log(`🚪 Access ${allowed ? 'GRANTED' : 'DENIED'}\n`);
   
@@ -229,7 +230,7 @@ async function serveDebug(res) {
     codes_count: codes.length,
     codes: codes.map(code => ({
       pin: code.pin,
-      user: code.user,
+      user: code.user || code.username,
       days: code.days,
       schedule: `${code.start} - ${code.end}`,
       currently_allowed: codeAllowed(code)
@@ -284,10 +285,11 @@ async function handleOpen(req, res) {
 
       // Send webhook and wait for response
       forwardWebhook(async (error) => {
+        const user = code.user || code.username || 'Unknown';
         if (error) {
           // Webhook failed
-          console.error(`❌ Gate opening failed for ${code.user}: ${error.message}`);
-          await appendLog(pin, code.user, false, error.message);
+          console.error(`❌ Gate opening failed for ${user}: ${error.message}`);
+          await appendLog(pin, user, false, error.message);
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ 
             ok: false, 
@@ -295,8 +297,8 @@ async function handleOpen(req, res) {
           }));
         } else {
           // Webhook succeeded
-          console.log(`✅ Gate opened successfully for ${code.user}`);
-          await appendLog(pin, code.user, true);
+          console.log(`✅ Gate opened successfully for ${user}`);
+          await appendLog(pin, user, true);
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: true }));
         }


### PR DESCRIPTION
## Summary
- standardize on `user` name for codes
- keep older `username` values as fallback in the UI and API
- avoid undefined names in logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852be3cac248323832cdff9044bfc26