### PR TITLE
Improve username handling

### DIFF
--- a/admin-logs.html
+++ b/admin-logs.html
@@ -57,7 +57,7 @@
         } else {
           data.entries.forEach(e => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.username || 'Desconocido'}</td><td>${e.pin}</td>`;
+            tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.user || e.username || 'Desconocido'}</td><td>${e.pin}</td>`;
             tbody.appendChild(tr);
           });
         }

--- a/admin.html
+++ b/admin.html
@@ -154,7 +154,7 @@
         document.getElementById('edit-pin').value = pin;
         document.getElementById('new-pin').value = pin;
         document.getElementById('new-pin').disabled = true;
-        document.getElementById('new-user').value = code.username;
+        document.getElementById('new-user').value = code.user || code.username || '';
         document.getElementById('hora-inicio').value = code.start_time;
         document.getElementById('hora-fin').value = code.end_time;
 

--- a/netlify/functions/codes.js
+++ b/netlify/functions/codes.js
@@ -77,9 +77,10 @@ exports.handler = async (event, context) => {
           body: JSON.stringify({ error: 'PIN inválido' })
         };
       }
+      const username = data.user || data.username || '';
       await saveCode({
         pin,
-        username: data.username || '',
+        username,
         days: Array.isArray(data.days) ? data.days : [],
         start_time: data.start_time || '00:00',
         end_time: data.end_time || '23:59'
@@ -95,8 +96,9 @@ exports.handler = async (event, context) => {
     if (event.httpMethod === 'PUT') {
       const pin = decodeURIComponent(event.path.split('/').pop());
       const data = JSON.parse(event.body || '{}');
+      const username = data.user || data.username || '';
       await updateCode(pin, {
-        username: data.username || '',
+        username,
         days: Array.isArray(data.days) ? data.days : [],
         start_time: data.start_time || '00:00',
         end_time: data.end_time || '23:59'

--- a/netlify/functions/open.js
+++ b/netlify/functions/open.js
@@ -133,7 +133,7 @@ exports.handler = async (event, context) => {
       };
     }
 
-    console.log(`Netlify function: PIN ${pin} accepted for user ${code.user}`);
+    console.log(`Netlify function: PIN ${pin} accepted for user ${code.user || code.username || 'Unknown'}`);
     await appendLog(pin, code.user);
 
     try {

--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ function codeAllowed(code) {
   const now = new Date(getCurrentTimeInTimezone());
   const day = now.getDay();
   
-  console.log(`Checking code for user ${code.user}:`);
+  console.log(`Checking code for user ${code.user || code.username || 'Unknown'}:`);
   console.log(`  Current time (${TIMEZONE}): ${now.toLocaleString()}`);
   console.log(`  Current day: ${day} (0=Sunday, 6=Saturday)`);
   console.log(`  Allowed days: [${code.days.join(', ')}]`);
@@ -85,7 +85,7 @@ async function pinAllowed(pin) {
     return null;
   }
   
-  console.log(`✅ PIN found for user: ${data.user}`);
+  console.log(`✅ PIN found for user: ${data.user || data.username || 'Unknown'}`);
   const allowed = codeAllowed(data);
   console.log(`🚪 Access ${allowed ? 'GRANTED' : 'DENIED'}\n`);
   
@@ -286,7 +286,7 @@ async function handleOpen(req, res) {
       forwardWebhook(async (error) => {
         if (error) {
           // Webhook failed
-          console.error(`❌ Gate opening failed for ${code.user}: ${error.message}`);
+          console.error(`❌ Gate opening failed for ${code.user || code.username || 'Unknown'}: ${error.message}`);
           await appendLog(pin, code.user, false, error.message);
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ 
@@ -295,7 +295,7 @@ async function handleOpen(req, res) {
           }));
         } else {
           // Webhook succeeded
-          console.log(`✅ Gate opened successfully for ${code.user}`);
+          console.log(`✅ Gate opened successfully for ${code.user || code.username || 'Unknown'}`);
           await appendLog(pin, code.user, true);
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: true }));


### PR DESCRIPTION
## Summary
- allow editing user or username
- show fallback username in logs view
- support both user and username in Netlify functions
- log username when opening gate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852c588d0b48323ab1138294fd4839c