### PR TITLE
Use start_time/end_time consistently

### DIFF
--- a/netlify/functions/open.js
+++ b/netlify/functions/open.js
@@ -25,7 +25,7 @@ function codeAllowed(code) {
   if (!code.days.includes(day)) return false;
   const cur = now.getHours() * 60 + now.getMinutes();
   
-  // Support both old and new column names
+  // Use new field names with fallback for older records
   const startTime = code.start_time || code.start || '00:00';
   const endTime = code.end_time || code.end || '23:59';
   


### PR DESCRIPTION
## Summary
- normalize time field names
- update Node server to read/write `start_time` and `end_time`
- adjust Netlify function to match

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852c58a37848323bbcd92c7534a26cb