### PR TITLE
Fix timezone formatting on admin pages

### DIFF
--- a/admin-logs.html
+++ b/admin-logs.html
@@ -40,6 +40,8 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script>
+    const TZ = 'America/Costa_Rica';
+
     async function cargarLogs() {
       try {
         const res = await fetch('/logs');
@@ -57,7 +59,7 @@
         } else {
           data.entries.forEach(e => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.username || 'Desconocido'}</td><td>${e.pin}</td>`;
+            tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString('es-CR', { timeZone: TZ })}</td><td>${e.username || 'Desconocido'}</td><td>${e.pin}</td>`;
             tbody.appendChild(tr);
           });
         }

--- a/admin.html
+++ b/admin.html
@@ -698,6 +698,7 @@
   <script>
     // ✅ URL de Railway configurada
     const BACKEND_URL = 'https://gate-production-d17a.up.railway.app';
+    const TZ = 'America/Costa_Rica';
 
     let allLogs = [];
     let allCodes = [];
@@ -735,7 +736,7 @@
     }
 
     function addSystemLog(message, type = 'info') {
-      const timestamp = new Date().toLocaleString();
+      const timestamp = new Date().toLocaleString('es-CR', { timeZone: TZ });
       systemLogs.unshift(`[${timestamp}] [${type.toUpperCase()}] ${message}`);
       if (systemLogs.length > 100) systemLogs = systemLogs.slice(0, 100);
     }
@@ -852,7 +853,7 @@
               <span class="badge ${isToday ? 'bg-success' : 'bg-secondary'} me-2">
                 ${isToday ? 'HOY' : ''}
               </span>
-              ${date.toLocaleString()}
+              ${date.toLocaleString('es-CR', { timeZone: TZ })}
             </td>
             <td>
               <i class="fas fa-user-circle text-primary me-2"></i>
@@ -901,7 +902,7 @@
           <div class="d-flex justify-content-between align-items-center mb-2 p-2 bg-light rounded">
             <div>
               <strong>${log.user || 'Desconocido'}</strong><br>
-              <small class="text-muted">${new Date(log.timestamp).toLocaleString()}</small>
+              <small class="text-muted">${new Date(log.timestamp).toLocaleString('es-CR', { timeZone: TZ })}</small>
             </div>
             <span class="badge ${log.success !== false ? 'bg-success' : 'bg-danger'}">
               ${log.success !== false ? 'OK' : 'Error'}


### PR DESCRIPTION
## Summary
- configure timezone constant in `admin.html` and `admin-logs.html`
- format all timestamps with the timezone

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6853006491f48323992ab225a1830c14