### PR TITLE
Update admin badge styles and logs table

### DIFF
--- a/admin-logs.html
+++ b/admin-logs.html
@@ -6,6 +6,24 @@
   <title>Registro de Logs</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
+  <style>
+    .status-badge {
+      padding: 4px 10px;
+      border-radius: 20px;
+      font-weight: 600;
+      font-size: 0.85rem;
+    }
+
+    .status-active {
+      background: #28a745;
+      color: #fff;
+    }
+
+    .status-inactive {
+      background: #dc3545;
+      color: #fff;
+    }
+  </style>
 </head>
 <body class="bg-light">
   <header class="p-3 mb-4 border-bottom bg-body-tertiary">
@@ -32,6 +50,7 @@
           <th>Fecha y Hora</th>
           <th>Usuario</th>
           <th>PIN</th>
+          <th>Estado</th>
         </tr>
       </thead>
       <tbody></tbody>
@@ -52,12 +71,18 @@
         tbody.innerHTML = '';
         if (data.entries.length === 0) {
           const tr = document.createElement('tr');
-          tr.innerHTML = '<td colspan="3" class="text-center">Sin registros</td>';
+          tr.innerHTML = '<td colspan="4" class="text-center">Sin registros</td>';
           tbody.appendChild(tr);
         } else {
           data.entries.forEach(e => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${new Date(e.timestamp).toLocaleString()}</td><td>${e.username || 'Desconocido'}</td><td>${e.pin}</td>`;
+            const user = e.username || e.user || 'Desconocido';
+            const status = e.success !== false;
+            tr.innerHTML = `
+              <td>${new Date(e.timestamp).toLocaleString()}</td>
+              <td>${user}</td>
+              <td>${e.pin}</td>
+              <td><span class="status-badge ${status ? 'status-active' : 'status-inactive'}">${status ? 'Exitoso' : 'Fallido'}</span></td>`;
             tbody.appendChild(tr);
           });
         }

--- a/admin.html
+++ b/admin.html
@@ -170,13 +170,13 @@
     }
     
     .status-active {
-      background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
-      color: white;
+      background: #28a745;
+      color: #fff;
     }
-    
+
     .status-inactive {
-      background: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
-      color: white;
+      background: #dc3545;
+      color: #fff;
     }
     
     .stats-card {


### PR DESCRIPTION
## Summary
- standardize badge colors for active/inactive status
- add badge styles to logs page
- show success/failure state in admin logs table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853006668708323a7397568f98861f5