### PR TITLE
Use Netlify functions by default

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -661,8 +661,8 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script>
-    // ✅ URL de Railway configurada
-    const BACKEND_URL = 'https://gate-production-d17a.up.railway.app';
+    // API base path (empty string when hosted on Netlify)
+    const BACKEND_URL = '';
     const TZ = 'America/Costa_Rica';
 
     let allLogs = [];

--- a/index.html
+++ b/index.html
@@ -220,8 +220,8 @@
   </div>
   
   <script>
-    // ✅ URL de Railway configurada
-    const BACKEND_URL = 'https://gate-production-d17a.up.railway.app';
+    // API base path (empty string when hosted on Netlify)
+    const BACKEND_URL = '';
     
     const DURACION_CIERRE = 38;
     let timerInterval;


### PR DESCRIPTION
## Summary
- point frontend to relative API path so it works when deployed to Netlify

## Testing
- `npx -y jest`

------
https://chatgpt.com/codex/tasks/task_e_68800eb661848323a73ca2d585dc9c0f