### PR TITLE
Implement Netlify test-webhook endpoint

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,6 +29,11 @@
   status = 200
 
 [[redirects]]
+  from = "/test-webhook"
+  to = "/.netlify/functions/test-webhook"
+  status = 200
+
+[[redirects]]
   from = "/admin/logs"
   to = "/admin-logs.html"
   status = 200

--- a/netlify/functions/test-webhook.js
+++ b/netlify/functions/test-webhook.js
@@ -1,0 +1,37 @@
+const getNow = () => {
+  const tz = process.env.TIMEZONE || 'America/Costa_Rica';
+  return new Date(new Date().toLocaleString('en-US', { timeZone: tz }));
+};
+
+exports.handler = async (event, context) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers, body: '' };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: 'Method not allowed' })
+    };
+  }
+
+  console.log('Netlify function: test webhook called');
+
+  return {
+    statusCode: 200,
+    headers,
+    body: JSON.stringify({
+      ok: true,
+      message: 'Test webhook funcionando correctamente',
+      timestamp: getNow().toISOString()
+    })
+  };
+};


### PR DESCRIPTION
## Summary
- create `test-webhook` Netlify function
- add redirect for `/test-webhook` in `netlify.toml`

## Testing
- `npx jest --colors` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_6880f71d0a748323ae8e8edd116f37c6