### PR TITLE
Fix webhook default URL

### DIFF
--- a/netlify/functions/open.js
+++ b/netlify/functions/open.js
@@ -6,8 +6,9 @@ const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
-const WEBHOOK_URL = process.env.WEBHOOK_URL ||
-  'https://dyaxguerproyd2kte4awwggu9ylh6rsd.ui.nabu.casa/api/webhook/porton_martes';
+const WEBHOOK_URL =
+  process.env.WEBHOOK_URL ||
+  'https://dyaxguerproyd2kte4awwggu9ylh6rsd.ui.nabu.casa/api/webhook/porton_abrir';
 
 function minutes(t) {
   const [h, m] = t.split(':').map(Number);


### PR DESCRIPTION
## Summary
- correct the default Home Assistant webhook used in the Netlify function

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68814b4dcbf0832392ab8933af17a0cc